### PR TITLE
Fix issue in compgen.cmd

### DIFF
--- a/bin/compgen.cmd
+++ b/bin/compgen.cmd
@@ -68,7 +68,7 @@ def getCliOptScriptPath(): Os.Path = {
  */
 def run(script: Os.Path): Os.Proc.Result = {
   val home = Os.slashDir.canon
-  val prefix: ISZ[String] = if (Os.kind == Os.Kind.Win) ISZ("cmd", "/c") else ISZ[String]()
+  val prefix: ISZ[String] = if (Os.kind == Os.Kind.Win) ISZ("cmd", "/c") else ISZ("sh")
   val proc: ISZ[String] = ISZ("sireum", "slang", "run", script.value)
   return Os.proc(prefix ++ proc).at(home).runCheck()
 }


### PR DESCRIPTION
If a macOS/Linux user runs `bin/compgen.cmd /path/to/cli.sc` on a non-POSIX shell, then the script will error and halt prematurely. This is fixed by prepending `"sh"` to the `Os.proc` command list before `proc.run()` on macOS/Linux. [Very similar to this code in kekinian.](https://github.com/sireum/runtime/blob/435a28753dfc4ab66547722fb7315b4f0b902320/library/jvm/src/main/scala/org/sireum/Os.scala#L556)

Let me know if you'd like me to make any additional edits. Thanks!
